### PR TITLE
Interrupt pending eval when region is erased

### DIFF
--- a/package.py
+++ b/package.py
@@ -201,6 +201,8 @@ class Connection:
         eval.erase()
         del self.evals[eval.id]
         del self.evals_by_view[eval.view.id()][eval.id]
+        if eval.status == "pending" and (session := eval.msg.get("session")):
+            conn.send({"op": "interrupt", "interrupt-id": eval.id, "session": session})
 
     def find_eval(self, view, region):
         for eval in self.evals_by_view[view.id()].values():


### PR DESCRIPTION
Closes #16.

Unfortunately, it appears that ephemeral sessions [can't really be interrupted](https://github.com/nrepl/nrepl/blob/5c9c47d84204fb1dc3e7657920e9a968f107b536/src/clojure/nrepl/middleware/session.clj#L263-L264). Or at least, I couldn't get that to work.

So, I'm doing it only when sessions are being used, which happens when `eval_in_session` is true in the package settings.