### PR TITLE
Add a command to require namespace of symbol at point

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -40,4 +40,9 @@
  // {"keys": ["ctrl+c"],
  //  "command": "clojure_sublimed_copy",
  //  "context": [{"key": "selector", "operator": "equal", "operand": "source.clojure"}]},
+
+ // // Require Namespace
+ // {"keys": ["ctrl+alt+r"],
+ //  "command": "clojure_sublimed_require_namespace",
+ //  "context": [{"key": "selector", "operator": "equal", "operand": "source.clojure"}]},
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -40,4 +40,9 @@
  // {"keys": ["super+c"],
  //  "command": "clojure_sublimed_copy",
  //  "context": [{"key": "selector", "operator": "equal", "operand": "source.clojure"}]},
+
+ // // Require Namespace
+ // {"keys": ["ctrl+r"],
+ //  "command": "clojure_sublimed_require_namespace",
+ //  "context": [{"key": "selector", "operator": "equal", "operand": "source.clojure"}]},
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -40,4 +40,9 @@
  // {"keys": ["ctrl+c"],
  //  "command": "clojure_sublimed_copy",
  //  "context": [{"key": "selector", "operator": "equal", "operand": "source.clojure"}]},
+
+ // // Require Namespace
+ // {"keys": ["ctrl+alt+r"],
+ //  "command": "clojure_sublimed_require_namespace",
+ //  "context": [{"key": "selector", "operator": "equal", "operand": "source.clojure"}]},
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -44,6 +44,10 @@
         "command": "clojure_sublimed_clear_evals"
     },
     {
+        "caption": "Clojure Sublimed: Require Namespace",
+        "command": "clojure_sublimed_require_namespace"
+    },
+    {
         "caption": "Preferences: Clojure Sublimed Settings",
         "command": "edit_settings",
         "args": {


### PR DESCRIPTION
Closes #12.

Requires `clojure.pprint` when ran on `(clojure.pprint/pprint :a)` with the cursor on the symbol. If the symbol-at-point does not have a namespace prefix, it considers the whole symbol to be the name of the namespace (example: `(ns-publics 'clojure.pprint)`).