### PR TITLE
Avoid putting regions on the undo stack

### DIFF
--- a/package.py
+++ b/package.py
@@ -77,10 +77,10 @@ class Eval:
                             value = f"({'{:.0f}'.format(elapsed * 1000)} ms) {value}"
                         else:
                             value = f"({'{:.2f}'.format(elapsed * 1000)} ms) {value}"
-                self.view.add_regions(self.value_key(), [region], scope, '', sublime.DRAW_NO_FILL, [html.escape(value)], color)
+                self.view.add_regions(self.value_key(), [region], scope, '', sublime.DRAW_NO_FILL + sublime.NO_UNDO, [html.escape(value)], color)
             else:
                 self.view.erase_regions(self.value_key())
-                self.view.add_regions(self.value_key(), [region], scope, '', sublime.DRAW_NO_FILL)
+                self.view.add_regions(self.value_key(), [region], scope, '', sublime.DRAW_NO_FILL + sublime.NO_UNDO)
 
     def toggle_trace(self):
         if self.trace:


### PR DESCRIPTION
Closes #22.

There's some [discussion about this in the Sublime Forums](https://forum.sublimetext.com/t/add-regions-erase-regions-and-undo-history/35275). The **undocumented** `sublime.NO_UNDO` flag does the trick, but isn't satisfying (because it relies on something the API reference page does not mention). WDYT?