### PR TITLE
Added `Main.sublime-menu` file.

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,37 @@
+[
+  { "id": "preferences",
+    "children": [
+      { "caption": "Package Settings",
+        "mnemonic": "P",
+        "id": "package-settings",
+        "children": [
+          { "caption": "Clojure Sublimed",
+            "children": [
+              { "caption": "README",
+                "command": "open_file",
+                "args": {
+                  "file": "${packages}/Clojure-Sublimed/README.md"
+                }
+              },
+              { "caption": "-" },
+              { "caption": "Settings",
+                "command": "edit_settings",
+                "args": {
+                  "base_file": "${packages}/Clojure-Sublimed/Clojure Sublimed.sublime-settings",
+                  "default": "{\n\t$0\n}\n"
+                }
+              },
+              { "caption": "Key Bindings",
+                "command": "edit_settings",
+                "args": {
+                  "base_file": "${packages}/Clojure-Sublimed/Default (${platform}).sublime-keymap",
+                  "default": "[\n\t$0\n]\n"
+                }
+              },
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Hello.
Please check this small enhancement pr. 
It's goal to add next context menu to Sublime Preferences menu.


Before this enhancement I had next situation

<img width="664" alt="Screenshot 2022-12-02 at 09 00 47" src="https://user-images.githubusercontent.com/497496/205244798-0a561237-d580-4868-ba38-b902c3e0b9b3.png">

Aftter adding this Menu
<img width="750" alt="Screenshot 2022-12-02 at 09 01 08" src="https://user-images.githubusercontent.com/497496/205244902-e1a14727-9c10-4c69-98dc-81927da678ce.png">


And now it's possible to access keybingings and package settings 
 

<img width="1082" alt="Screenshot 2022-12-02 at 09 04 03" src="https://user-images.githubusercontent.com/497496/205245137-9c89fdb6-0fe3-4e2b-b80a-37af7b16630f.png">

Sublime text version - 4
Sublime build - 4143
