### PR TITLE
Tweak example code in readme for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ To support such use cases, Clojure Sublimed allows you to bind arbitrary piece o
 ```
 {"keys": ["ctrl+t"],
  "command": "clojure_sublimed_eval_code",
- "args": {"code": "(clojure.test/run-all-tests)"}}
+ "args": {"code": "(clojure.test/run-all-tests (re-pattern (str *ns*))))"}}
 ```
 
 Then, whenever you press <key>Ctrl</key> + <key>T</key>, you’ll see the result in the status bar, like this:


### PR DESCRIPTION
I found that the prior example led to a very noisy test report in my terminal, which made it a chore to scroll to the output of the specific test ns I was working on. I suspect this might be a better default for folks like me who may not be experts in the machinery of `clojure.test` and the various ways to run the tests, etc.