### PR TITLE
Add socket repl eval code escaping

### DIFF
--- a/cs_conn_socket_repl.py
+++ b/cs_conn_socket_repl.py
@@ -116,7 +116,7 @@ class ConnectionSocketRepl(cs_conn.Connection):
         cs_warn.reset_warnings(self.window)
         batch_id = cs_eval.Eval.next_id()
         eval = cs_eval_status.StatusEval(code, id = f'{batch_id}.0', batch_id = batch_id)
-        form = cs_common.Form(id = batch_id, code = code, ns = ns)
+        form = cs_common.Form(id = batch_id, code = code.replace('\\', '\\\\').replace('"', '\\"'), ns = ns)
         self.eval_impl(form)
 
     def load_file(self, view):


### PR DESCRIPTION
Fixes different escaping behavior for socket repl connection and others.

Steps to reproduce the issue:

1. Create a `ClojureSublimedEvalCode` hotkey with `"` in the code:
   ```
   {"keys": ["ctrl+h"],
    "command": "clojure_sublimed_eval_code",
    "args": {"code": "\"Hello!\""}}
   ```
2. Connect to a raw nREPL and press `ctrl+h`. You'll see `✅ "Hello!"` in the status line
3. Connect to a socket REPL and press `ctrl+h`. You'll see `⏳ "Hello!"` in the status line

Another way to reproduce the issue:
1. Create a `ClojureSublimedEvalCode` hotkey with `"` in the code:
   ```
   {"keys": ["ctrl+h"],
    "command": "clojure_sublimed_eval_code",
    "args": {"code": "(str \"Hello!\")"}}
   ```
2. Connect to a raw nREPL and press `ctrl+h`. You'll see `✅ "Hello!"` in the status line
3. Connect to a socket REPL and press `ctrl+h`. You'll see `❌ RuntimeException: EOF while reading` in the status line


This PR fixes the issue in both cases