### PR TITLE
Fix cs_parser children mutable default

### DIFF
--- a/cs_parser.py
+++ b/cs_parser.py
@@ -7,10 +7,10 @@ class Node:
     Optional children. Name from Named ('token', 'string' etc).
     Text is substring[start:end], only for terminal nodes like Regex or String
     """
-    def __init__(self, start, end, children = [], name = None, text = None):
+    def __init__(self, start, end, children = None, name = None, text = None):
         self.start = start
         self.end = end
-        self.children = children
+        self.children = children if children is not None else []
         self.name = name
         self.text = text
 


### PR DESCRIPTION
Currently all nodes without children share the same list object
https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments

This may not affect parser logic right now, but if someone decides to append a child into a such node, this would affect all nodes without children